### PR TITLE
Avoid IndexOutOfRangeException

### DIFF
--- a/Manager/TFSBuildManager.Views/ViewModels/BuildDefinitionViewModel.cs
+++ b/Manager/TFSBuildManager.Views/ViewModels/BuildDefinitionViewModel.cs
@@ -24,7 +24,9 @@ namespace TfsBuildManager.Views
             this.Uri = build.Uri;
             this.TeamProject = build.TeamProject;
             this.ContinuousIntegrationType = GetFriendlyTriggerName(build.ContinuousIntegrationType);
-            if (build.ContinuousIntegrationType == Microsoft.TeamFoundation.Build.Client.ContinuousIntegrationType.Schedule || build.ContinuousIntegrationType == Microsoft.TeamFoundation.Build.Client.ContinuousIntegrationType.ScheduleForced)
+            if ((build.ContinuousIntegrationType == Microsoft.TeamFoundation.Build.Client.ContinuousIntegrationType.Schedule || 
+                build.ContinuousIntegrationType == Microsoft.TeamFoundation.Build.Client.ContinuousIntegrationType.ScheduleForced) &&
+                build.Schedules.Count > 0)
             {
                 this.ContinuousIntegrationType = string.Format("{0} - {1}", this.ContinuousIntegrationType, ConvertTime(build.Schedules[0].StartTime.ToString(CultureInfo.CurrentCulture)));
             }


### PR DESCRIPTION
Avoid IndexOutOfRangeException if the build is set to be scheduled but there are actually no schedules.

This happened in our project once and because of this issue, some of the builds are not shown at all.
It would be nice to include this fix in the next release.

Thanks,
Tamas